### PR TITLE
introduce Google Analytics GitBook Plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,6 +3,12 @@
   "title": "Maven3のはじめかた",
   "author": "Kengo TODA",
   "language": "ja",
+  "plugins": ["ga"],
+  "pluginsConfig": {
+    "ga": {
+      "token": "UA-111696302-1"
+    }
+  },
   "variables": {
     "version": {
       "maven": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "gitbook-cli": "^2.3.2",
+    "gitbook-plugin-ga": "^1.0.0",
     "textlint": "^7.4.0",
     "textlint-rule-max-ten": "^2.0.3",
     "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",


### PR DESCRIPTION
Note that [plugin-ga v2 depends on GitBook v4](https://github.com/GitbookIO/plugin-ga/blob/2.0.0/package.json), which is still alpha version.
To build with stable GitBook v3, I use plugin-ga v1.