### PR TITLE
install Japanese IPA fonts, to generate proper PDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo ln -s /opt/calibre/ebook-convert /usr/local/bin/
   # https://ipafont.ipa.go.jp/node26
   - wget -nv -O /tmp/ipaexm00301.zip https://oscdl.ipa.go.jp/IPAexfont/ipaexm00301.zip
+  - mkdir -p ~/.fonts
   - unzip -p /tmp/ipaexm00301.zip ipaexm00301/ipaexm.ttf > ~/.fonts/ipaexm.ttf
   - fc-cache -fv
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ before_install:
   # https://calibre-ebook.com/download_linux
   - sudo -v && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin
   - sudo ln -s /opt/calibre/ebook-convert /usr/local/bin/
+  # https://ipafont.ipa.go.jp/node26
+  - wget -nv -O /tmp/ipaexm00301.zip https://oscdl.ipa.go.jp/IPAexfont/ipaexm00301.zip
+  - unzip -p /tmp/ipaexm00301.zip ipaexm00301/ipaexm.ttf > ~/.fonts/ipaexm.ttf
+  - fc-cache -fv
 install:
   - npm install
   - ./mvnw install -DskipTests=true -B

--- a/book.json
+++ b/book.json
@@ -15,5 +15,8 @@
       "junit": "4.12",
       "jdk": "8"
     }
+  },
+  "pdf": {
+    "fontFamily": "IPAexMincho"
   }
 }


### PR DESCRIPTION
Travis CI's worker node has no Japanese fonts, so generated PDF is almost broken.
This PR installs IPA fonts to worker node, to make PDF readable for human.

* [before.pdf](https://github.com/KengoTODA/what-is-maven/files/2243796/before.pdf)
* [after.pdf](https://github.com/KengoTODA/what-is-maven/files/2243797/after.pdf)
