### PR TITLE
Use markdown code blocks

### DIFF
--- a/implement-plugin/create-project.md
+++ b/implement-plugin/create-project.md
@@ -19,54 +19,55 @@
 
 `pom.xml`の概要は次のようになります。
 
-<!-- disable:prh --><pre><code class="lang-xml">&lt;project&gt;
-  &lt;artifactId&gt;sample-maven-plugin&lt;/artifactId&gt;
-  &lt;packaging&gt;maven-plugin&lt;/packaging&gt;
+```xml
+<project>
+  <artifactId>sample-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
 
-  <!-- disable:prh -->&lt;dependencies&gt;
-    &lt;dependency&gt;
-      &lt;groupId&gt;org.apache.maven&lt;/groupId&gt;
-      &lt;artifactId&gt;maven-plugin-api&lt;/artifactId&gt;
-      &lt;version&gt;{{book.version.maven}}&lt;/version&gt;&lt;!-- version of Maven --&gt;
-      &lt;scope&gt;provided&lt;/scope&gt;
-    &lt;/dependency&gt;
-    &lt;dependency&gt;
-      &lt;groupId&gt;org.apache.maven.plugin-tools&lt;/groupId&gt;
-      &lt;artifactId&gt;maven-plugin-annotations&lt;/artifactId&gt;
-      &lt;version&gt;3.4&lt;/version&gt;&lt;!-- version of Maven Plugin Tools --&gt;
-      &lt;scope&gt;provided&lt;/scope&gt;
-    &lt;/dependency&gt;
-    &lt;dependency&gt;
-      &lt;groupId&gt;junit&lt;/groupId&gt;
-      &lt;artifactId&gt;junit&lt;/artifactId&gt;
-      &lt;version&gt;{{book.version.junit}}&lt;/version&gt;
-      &lt;scope&gt;test&lt;/scope&gt;
-    &lt;/dependency&gt;
-  &lt;/dependencies&gt;
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>{{book.version.maven}}</version><!-- version of Maven -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.4</version><!-- version of Maven Plugin Tools -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>{{book.version.junit}}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-  <!-- disable:prh -->&lt;build&gt;
-    &lt;plugins&gt;
-      &lt;plugin&gt;
-        &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
-        &lt;artifactId&gt;maven-plugin-plugin&lt;/artifactId&gt;
-        &lt;version&gt;3.4&lt;/version&gt;
-        &lt;executions&gt;
-          &lt;execution&gt;
-            &lt;id&gt;default-descriptor&lt;/id&gt;
-            &lt;phase&gt;process-classes&lt;/phase&gt;
-          &lt;/execution&gt;
-          &lt;execution&gt;
-            &lt;id&gt;generate-helpmojo&lt;/id&gt;
-            &lt;goals&gt;
-              &lt;goal&gt;helpmojo&lt;/goal&gt;
-            &lt;/goals&gt;
-          &lt;/execution&gt;
-        &lt;/executions&gt;
-      &lt;/plugin&gt;
-    &lt;/plugins&gt;
-  &lt;/build&gt;</code></pre>
-
-<!-- textlint-enable spellcheck-tech-word -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.4</version>
+        <executions>
+          <execution>
+            <id>default-descriptor</id>
+            <phase>process-classes</phase>
+          </execution>
+          <execution>
+            <id>generate-helpmojo</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
 
 なお、archetypeプラグインを利用するとpom.xmlを自動的に生成してくれます[^3]ので、
 スクラッチで実装する場合はぜひ利用してください。次のコマンドでMavenプロジェクトの作成を行えます。

--- a/implement-plugin/unit-test.md
+++ b/implement-plugin/unit-test.md
@@ -9,21 +9,23 @@ Mavenプラグインのユニットテストを作成するために、`maven-pl
 まずJUnitと`maven-plugin-testing-harness`を使用するために、以下2つの`<dependency>`を
 `pom.xml`に追加します。
 
-<pre><code class="lang-xml">&lt;dependencies&gt;
+```xml
+<dependencies>
   ...
-  &lt;dependency&gt;
-    &lt;groupId&gt;junit&lt;/groupId&gt;
-    &lt;artifactId&gt;junit&lt;/artifactId&gt;
-    &lt;version&gt;{{book.version.junit}}&lt;/version&gt;
-    &lt;scope&gt;test&lt;/scope&gt;
-  &lt;/dependency&gt;
-  &lt;dependency&gt;
-    &lt;groupId&gt;org.apache.maven.plugin-testing&lt;/groupId&gt;
-    &lt;artifactId&gt;maven-plugin-testing-harness&lt;/artifactId&gt;
-    &lt;version&gt;3.3.0&lt;/version&gt;
-    &lt;scope&gt;test&lt;/scope&gt;
-  &lt;/dependency&gt;
-&lt;/dependencies&gt;</code></pre>
+  <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>{{book.version.junit}}</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.maven.plugin-testing</groupId>
+    <artifactId>maven-plugin-testing-harness</artifactId>
+    <version>3.3.0</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>
+```
 
 ## ユニットテストを作成する
 

--- a/primer/dependency.md
+++ b/primer/dependency.md
@@ -3,9 +3,11 @@
 プロジェクトをビルドするときに、JDKだけでなくライブラリを必要とすることがあります。このことを「プロジェクトはライブラリに[依存している](http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html)」と表現します。
 Mavenではプロジェクトがライブラリに依存していることを次のように明記できます。
 
-<pre><code class="lang-xml">&lt;dependency&gt;&lt;!-- このプロジェクトはJUnit バージョン{{book.version.junit}}に依存している --&gt;
-  &lt;groupId&gt;junit&lt;/groupId&gt;
-  &lt;artifactId&gt;junit&lt;/artifactId&gt;
-  &lt;version&gt;{{book.version.junit}}&lt;/version&gt;
-  &lt;scope&gt;test&lt;/scope&gt;
-&lt;/dependency&gt;</code></pre>
+```xml
+<dependency><!-- このプロジェクトはJUnit バージョン{{book.version.junit}}に依存している -->
+  <groupId>junit</groupId>
+  <artifactId>junit</artifactId>
+  <version>{{book.version.junit}}</version>
+  <scope>test</scope>
+</dependency>
+```

--- a/primer/install.md
+++ b/primer/install.md
@@ -8,13 +8,14 @@ binディレクトリに実行可能ファイルが含まれていますので�
 最後に`mvn --version`を実行して、Mavenが正しく実行されること・意図どおりのJDKが認識されていることを確認してください。
 参考までに、執筆している環境では次のような出力が得られました。
 
-<pre><code class="lang-zsh">$ mvn --version
+```sh
+$ mvn --version
 Apache Maven 3.8.4 (9b656c72d54e5bacbed989b64718c159fe39b537)
 Maven home: /Users/kengo/.m2/wrapper/dists/apache-maven-3.8.4-bin/52ccbt68d252mdldqsfsn03jlf/apache-maven-3.8.4
 Java version: 11.0.13, vendor: GraalVM Community, runtime: /Users/kengo/Downloads/graalvm-ce-java11-21.3.0/Contents/Home
 Default locale: en_JP, platform encoding: UTF-8
 OS name: "mac os x", version: "12.0.1", arch: "x86_64", family: "mac"
-</core></pre>
+```
 
 このように、Mavenは`mvn`コマンドによって呼び出します。`--version`はMavenやJDKのバージョンを出力するための
 オプションです。オプションについては適宜解説していきます。


### PR DESCRIPTION
Using Markdown code blocks because pom.xml is broken.

Before
<img width="783" alt="スクリーンショット 2024-02-04 22 06 07" src="https://github.com/KengoTODA/what-is-maven/assets/92022336/ab145499-dc63-43cb-a56a-738725706be5">

After
<img width="799" alt="スクリーンショット 2024-02-04 22 05 46" src="https://github.com/KengoTODA/what-is-maven/assets/92022336/2079ce26-b88c-4c8f-87e4-7c763a0eb153">
